### PR TITLE
customizer+vertex filter update

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforMixedPF.py
+++ b/HLTrigger/Configuration/python/customizeHLTforMixedPF.py
@@ -3,12 +3,45 @@ from HLTrigger.Configuration.common import producers_by_type
 
 def customizeHLTForMixedPF(process):
 
-    #Not affecting the other seed producers
+    # Not affecting the other seed producers
     for producer in producers_by_type(process, "SeedGeneratorFromProtoTracksEDProducer"):
         producer.produceComplement = cms.bool(False)
 
     # Customization for the iter0 seeds
     process.hltIter0PFLowPixelSeedsFromPixelTracks.produceComplement = cms.bool(True)
+    
+    # Apply cuts for pixel tracks complement
+    process.hltPixelTracksLowPT = cms.EDProducer( "TrackWithVertexSelector",
+        normalizedChi2 = cms.double( 999999.0 ),
+        numberOfValidHits = cms.uint32( 0 ),
+        zetaVtx = cms.double( 0.3 ),
+        etaMin = cms.double( 0.0 ),
+        rhoVtx = cms.double( 0.2 ),
+        ptErrorCut = cms.double( 5.0 ),
+        dzMax = cms.double( 999.0 ),
+        etaMax = cms.double( 5.0 ),
+        quality = cms.string( "loose" ), ##loose, tight, highPurity
+        copyTrajectories = cms.untracked.bool( False ),
+        nSigmaDtVertex = cms.double( 0.0 ),
+        timesTag = cms.InputTag( "" ),
+        ptMin = cms.double( -1.0 ), # minimum pT cut
+        ptMax = cms.double( 6.0 ), # maximum pT cut
+        d0Max = cms.double( 999.0 ),
+        copyExtras = cms.untracked.bool( False ),
+        nVertices = cms.uint32( 2 ),
+        vertexTag = cms.InputTag( "hltPixelVertices" ),
+        src = cms.InputTag( "hltIter0PFLowPixelSeedsFromPixelTracks" ), # the complement reco::TrackCollection
+        vtxFallback = cms.bool( True ),
+        numberOfLostHits = cms.uint32( 999 ),
+        numberOfValidPixelHits = cms.uint32( 3 ),
+        timeResosTag = cms.InputTag( "" ),
+        useVtx = cms.bool( False ) ## Turning off vertex selection
+    )
+
+
+
+    process.HLTIterativeTrackingIteration0 = cms.Sequence(process.hltIter0PFLowPixelSeedsFromPixelTracks+process.hltPixelTracksLowPT+process.hltIter0PFlowCkfTrackCandidates+process.hltIter0PFlowCtfWithMaterialTracks+process.hltIter0PFlowTrackCutClassifier+process.hltMergedTracks)
+
 
     # Merging Iter0 tracks with the complement of pixel tracks
     process.hltPFTracks = cms.EDProducer( "TrackListMerger",
@@ -19,10 +52,10 @@ def customizeHLTForMixedPF(process):
         Epsilon = cms.double( -0.001 ),
         MaxNormalizedChisq = cms.double( 1000.0 ),
         MinFound = cms.int32( 3 ),
-        TrackProducers = cms.VInputTag( 'hltIter0PFLowPixelSeedsFromPixelTracks','hltMergedTracks' ),
+        TrackProducers = cms.VInputTag( 'hltPixelTracksLowPT','hltMergedTracks' ),
         hasSelector = cms.vint32( 0, 0 ),
         indivShareFrac = cms.vdouble( 1.0, 1.0 ),
-        selectedTrackQuals = cms.VInputTag( 'hltIter0PFLowPixelSeedsFromPixelTracks','hltMergedTracks' ),
+        selectedTrackQuals = cms.VInputTag( 'hltPixelTracksLowPT','hltMergedTracks' ),
         setsToMerge = cms.VPSet(
           cms.PSet(  pQual = cms.bool( False ),
             tLists = cms.vint32( 0, 1 )
@@ -36,7 +69,13 @@ def customizeHLTForMixedPF(process):
         copyMVA = cms.bool( False )
     )
 
-    # Using these mixed tracks as input for hltPFTracks
-    process.hltParticleFlowBlock.elementImporters.source = cms.InputTag("hltPFTracks")
+    # Merging these tracks with muons for final mixed tracks collection
+    process.hltPFMuonMerging.selectedTrackQuals = cms.VInputTag("hltIterL3MuonTracks", "hltPFTracks")
+    process.hltPFMuonMerging.TrackProducers = cms.VInputTag("hltIterL3MuonTracks", "hltPFTracks")
+    
+    process.HLTTrackReconstructionForPF = cms.Sequence(process.HLTDoLocalPixelSequence+process.HLTRecopixelvertexingSequence+process.HLTDoLocalStripSequence+process.HLTIterativeTrackingIter02+process.hltPFTracks+process.hltPFMuonMerging+process.hltMuonLinks+process.hltMuons)
+
+    # Customize the full hlt vertices such that they do not use the complement tracks by requiring at least 1 valid strip hit
+    process.hltVerticesPF.TkFilterParameters.minValidStripHits = cms.int32(1)
 
     return process

--- a/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
@@ -24,7 +24,7 @@ public:
 private:
   float maxD0Sig_, minPt_, maxEta_;
   float maxD0Error_, maxDzError_;
-  int minSiLayers_, minPxLayers_;
+  int minSiLayers_, minPxLayers_, minStripHits_;
   float maxNormChi2_;
   reco::TrackBase::TrackQuality quality_;
 };

--- a/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
@@ -10,7 +10,8 @@ TrackFilterForPVFinding::TrackFilterForPVFinding(const edm::ParameterSet& conf) 
   maxNormChi2_ = conf.getParameter<double>("maxNormalizedChi2");
   minSiLayers_ = conf.getParameter<int>("minSiliconLayersWithHits");
   minPxLayers_ = conf.getParameter<int>("minPixelLayersWithHits");
-
+  minStripHits_ = conf.getParameter<int>("minValidStripHits");
+  
   // the next few lines are taken from RecoBTag/SecondaryVertex/interface/TrackSelector.h"
   std::string qualityClass = conf.getParameter<std::string>("trackQuality");
   if (qualityClass == "any" || qualityClass == "Any" || qualityClass == "ANY" || qualityClass.empty()) {
@@ -33,8 +34,9 @@ bool TrackFilterForPVFinding::operator()(const reco::TransientTrack& tk) const {
   bool nPxLayCut = tk.hitPattern().pixelLayersWithMeasurement() >= minPxLayers_;
   bool nSiLayCut = tk.hitPattern().trackerLayersWithMeasurement() >= minSiLayers_;
   bool trackQualityCut = (quality_ == reco::TrackBase::undefQuality) || tk.track().quality(quality_);
+  bool nStripHitsCut = tk.hitPattern().numberOfValidStripHits() >= minStripHits_;
 
-  return IPSigCut && pTCut && etaCut && normChi2Cut && nPxLayCut && nSiLayCut && trackQualityCut;
+  return IPSigCut && pTCut && etaCut && normChi2Cut && nPxLayCut && nSiLayCut && trackQualityCut && nStripHitsCut;
 }
 
 // select the vector of tracks that pass the filter cuts
@@ -59,4 +61,5 @@ void TrackFilterForPVFinding::fillPSetDescription(edm::ParameterSetDescription& 
   desc.add<std::string>("trackQuality", "any");
   desc.add<int>("minPixelLayersWithHits", 2);
   desc.add<int>("minSiliconLayersWithHits", 5);
+  desc.add<int>("minValidStripHits", 0);
 }


### PR DESCRIPTION
Updated version of customizer for mixed tracking.
Option to use in filtering of tracks in vertex clustering based on valid strip hits (to remove pixel ones).